### PR TITLE
Allow use of /skull command for plus role

### DIFF
--- a/permissions/plugins/essentials.txt
+++ b/permissions/plugins/essentials.txt
@@ -40,6 +40,9 @@ if plugin Essentials
   permit plus essentials.back.ondeath
   permit plus essentials.teleport.timer.bypass
   permit plus essentials.keepxp
+  if server == creative
+    permit plus essentials.skull
+    permit plus essentials.skull.*
   permit pluspaid essentials.sethome.multiple
   permit pluspaid essentials.sethome.multiple.emerald
 


### PR DESCRIPTION
Giving essentials.skull & essentials.skull.* to plus in creative allowing them to use /skull command for their own skull, that of others, and also allowing the modification of an already held skull.