### PR TITLE
Move essentials.hat from Admin to Plus & BungeeCompass update

### DIFF
--- a/permissions/plugins/bungeecompass.txt
+++ b/permissions/plugins/bungeecompass.txt
@@ -1,2 +1,3 @@
 if plugin BungeeCompass
+  permit default bungeecompass.givecompass
   permit default bungeecompass.menu

--- a/permissions/plugins/essentials.txt
+++ b/permissions/plugins/essentials.txt
@@ -40,6 +40,7 @@ if plugin Essentials
   permit plus essentials.back.ondeath
   permit plus essentials.teleport.timer.bypass
   permit plus essentials.keepxp
+  permit plus essentials.hat
   if server == creative
     permit plus essentials.skull
     permit plus essentials.skull.*
@@ -89,7 +90,6 @@ if plugin Essentials
   permit admin essentials.fly.others
   permit admin essentials.god.others
   permit admin essentials.god.pvp
-  permit admin essentials.hat
   permit admin essentials.heal.cooldown.bypass
   permit admin essentials.heal.others
   permit admin essentials.speed


### PR DESCRIPTION
Giving essentials.hat as a donor perk is another reason why players might wish to purchase Plus