### PR TITLE
Give default access to /givecompass

### DIFF
--- a/permissions/plugins/bungeecompass.txt
+++ b/permissions/plugins/bungeecompass.txt
@@ -1,2 +1,4 @@
 if plugin BungeeCompass
+  permit default bungeecompass.givecompass
   permit default bungeecompass.menu
+  


### PR DESCRIPTION
For survival modes where it's not forced and not given automatically