### PR TITLE
Actually allow Admin /enchant

### DIFF
--- a/permissions/plugins/essentials.txt
+++ b/permissions/plugins/essentials.txt
@@ -143,6 +143,7 @@ if plugin Essentials
   permit admin essentials.setspawn
   permit admin essentials.item
   permit admin essentials.enchant
+  permit admin essentials.enchant.*
   permit admin essentials.exp
   permit admin essentials.exp.give
   permit admin essentials.exp.give.others


### PR DESCRIPTION
Admin didn't have ess.enchant.*, practically making /enchant useless 