### PR TITLE
Allow use of debug stick by Silver & Builder

### DIFF
--- a/permissions/bukkit.txt
+++ b/permissions/bukkit.txt
@@ -3,6 +3,11 @@ if server != bungee
   permit default -bukkit.command.plugins
   permit default -minecraft.command.me
   permit default -minecraft.command.tell
+
+  permit silver minecraft.debugstick
+
+  permit builder minecraft.debugstick
+
   permit admin bukkit.command.tps
   permit admin bukkit.command.version
   permit admin bukkit.command.plugins


### PR DESCRIPTION
Worldguard will deny use of debug stick in WG regions by default so that isn't a concern
Permission from: https://hub.spigotmc.org/jira/browse/SPIGOT-4640
Not sure if CoreProtect will detect debug stick usage, but the number of people with access to it will likely be small