### PR TITLE
ess home.others for moderator

### DIFF
--- a/permissions/plugins/essentials.txt
+++ b/permissions/plugins/essentials.txt
@@ -67,6 +67,7 @@ if plugin Essentials
   permit moderator essentials.fly
   permit moderator essentials.god
   permit moderator essentials.heal
+  permit moderator essentials.home.others
   permit moderator essentials.chat.ignoreexempt
   permit moderator essentials.near
   permit moderator essentials.enderchest


### PR DESCRIPTION
home.others allows users to run /home <User>:<home>. Can be useful for sniffing out abuse.